### PR TITLE
Add merge-all-constants compiler flag, saves 24 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ ifeq ($(ENABLE_OVERLAY),1)
 	ASFLAGS += -DENABLE_OVERLAY
 endif
 
-CFLAGS = -funroll-all-loops
+CFLAGS = -funroll-all-loops -fmerge-all-constants
 ifeq ($(ENABLE_CLANG),0)
 	CFLAGS += -Oz -Wall -Werror -mcpu=cortex-m0 -fshort-enums -fno-delete-null-pointer-checks -std=c2x -MMD
 	#CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=c2x -MMD


### PR DESCRIPTION
Testing more compiler options, found another to save some space

```
Voxless 1.0.1
arm-none-eabi-size f4hwn
   text	   data	    bss	    dec	    hex	filename
  61312	     52	   3140	  64504	   fbf8	f4hwn

Voxless 1.0.1 + -fmerge-all-constants
arm-none-eabi-size f4hwn
   text	   data	    bss	    dec	    hex	filename
  61288	     52	   3140	  64480	   fbe0	f4hwn
```