### PR TITLE
Pack ScanInfo 2 bytes hole

### DIFF
--- a/app/spectrum.h
+++ b/app/spectrum.h
@@ -139,8 +139,8 @@ typedef struct KeyboardState {
 typedef struct ScanInfo {
   uint16_t rssi, rssiMin, rssiMax;
   uint16_t i, iPeak;
-  uint32_t f, fPeak;
   uint16_t scanStep;
+  uint32_t f, fPeak;
   uint16_t measurementsCount;
 } ScanInfo;
 


### PR DESCRIPTION
Non-breaking change.  Pack the last struct that had a hole.  Does not affect the build size.